### PR TITLE
Don't use LDRD/STRD since memory access is not guaranteed to be aligned

### DIFF
--- a/src/jit/codegen_arm.cpp
+++ b/src/jit/codegen_arm.cpp
@@ -617,7 +617,12 @@ LOWFUNC(NONE,WRITE,2,compemu_raw_fmov_mr_drop,(MEMW mem, FR s))
 	  VSTR64_dRi(s, REG_WORK3, 0);
 	else {
 	  VMOV64_rrd(REG_WORK1, REG_WORK2, s);
+#ifdef ALLOW_UNALIGNED_LDRD
 	  STRD_rRI(REG_WORK1, REG_WORK3, 0);
+#else
+          STR_rRI(REG_WORK1, REG_WORK3, 0);
+          STR_rRI(REG_WORK2, REG_WORK3, 4);
+#endif
 	}
   }
 }
@@ -632,7 +637,12 @@ LOWFUNC(NONE,READ,2,compemu_raw_fmov_rm,(FW d, MEMR mem))
 	if((mem & 0x3) == 0)
 	  VLDR64_dRi(d, REG_WORK3, 0);
 	else {
+#ifdef ALLOW_UNALIGNED_LDRD
 		LDRD_rRI(REG_WORK1, REG_WORK3, 0);
+#else
+                LDR_rRI(REG_WORK1, REG_WORK3, 0);
+                LDR_rRI(REG_WORK2, REG_WORK3, 4);
+#endif
 		VMOV64_drr(d, REG_WORK1, REG_WORK2);
 	}
   }
@@ -752,7 +762,12 @@ LOWFUNC(NONE,READ,2,raw_fmov_d_rm,(FW r, MEMR m))
   if((m & 0x3) == 0)
 	VLDR64_dRi(r, REG_WORK3, 0);
   else {
+#ifdef ALLOW_UNALIGNED_LDRD
 	LDRD_rRI(REG_WORK1, REG_WORK3, 0);
+#else
+        LDR_rRI(REG_WORK1, REG_WORK3, 0);
+        LDR_rRI(REG_WORK2, REG_WORK3, 4);
+#endif
 	VMOV64_drr(r, REG_WORK1, REG_WORK2);
   }
 }
@@ -954,7 +969,7 @@ LOWFUNC(NONE,WRITE,2,raw_fp_from_exten_mr,(RR4 adr, FR s))
   VREV64_8_dd(SCRATCH_F64_1, SCRATCH_F64_1);
   VMOV64_rrd(REG_WORK1, REG_WORK2, SCRATCH_F64_1);
   ORR_rri(REG_WORK1, REG_WORK1, 0x80);  			// insert explicit 1
-#ifdef ARMV6T2
+#ifdef ALLOW_UNALIGNED_LDRD
   STRD_rRI(REG_WORK1, REG_WORK3, 4);
 #else
   STR_rRI(REG_WORK1, REG_WORK3, 4);
@@ -977,7 +992,7 @@ LOWFUNC(NONE,WRITE,2,raw_fp_from_exten_mr,(RR4 adr, FR s))
 	ADD_rrr(REG_WORK3, adr, R_MEMSTART);
 
   REV_rr(REG_WORK1, REG_WORK1);
-#ifdef ARMV6T2
+#ifdef ALLOW_UNALIGNED_LDRD
   STRD_rR(REG_WORK1, REG_WORK3);
 #else
   STR_rR(REG_WORK1, REG_WORK3);
@@ -994,7 +1009,7 @@ LOWFUNC(NONE,READ,2,raw_fp_to_exten_rm,(FW d, RR4 adr))
 {
 	ADD_rrr(REG_WORK3, adr, R_MEMSTART);
 
-#ifdef ARMV6T2
+#ifdef ALLOW_UNALIGNED_LDRD
 	LDRD_rRI(REG_WORK1, REG_WORK3, 4);
 #else
 	LDR_rRI(REG_WORK1, REG_WORK3, 4);
@@ -1050,14 +1065,24 @@ LOWFUNC(NONE,WRITE,2,raw_fp_from_double_mr,(RR4 adr, FR s))
 	ADD_rrr(REG_WORK3, adr, R_MEMSTART);
 	VREV64_8_dd(SCRATCH_F64_1, s);
   VMOV64_rrd(REG_WORK1, REG_WORK2, SCRATCH_F64_1);
+#ifdef ALLOW_UNALIGNED_LDRD
   STRD_rRI(REG_WORK1, REG_WORK3, 0);
+#else
+  STR_rRI(REG_WORK1, REG_WORK3, 0);
+  STR_rRI(REG_WORK2, REG_WORK3, 4);
+#endif
 }
 LENDFUNC(NONE,WRITE,2,raw_fp_from_double_mr,(RR4 adr, FR s))
 
 LOWFUNC(NONE,READ,2,raw_fp_to_double_rm,(FW d, RR4 adr))
 {
 	ADD_rrr(REG_WORK3, adr, R_MEMSTART);
+#ifdef ALLOW_UNALIGNED_LDRD
 	LDRD_rRI(REG_WORK1, REG_WORK3, 0);
+#else
+        LDR_rRI(REG_WORK1, REG_WORK3, 0);
+        LDR_rRI(REG_WORK2, REG_WORK3, 4);
+#endif
 	VMOV64_drr(d, REG_WORK1, REG_WORK2);
   VREV64_8_dd(d, d);
 }


### PR DESCRIPTION
I've encountered a problem when using the JIT on a 32 bit ARM binary running on a 64 bit ARM kernel. When the FPU JIT is turned on, Amiberry will crash with an alignment exception. A typical way to reproduce this is:

1. Start up Amiberry (using this HDF and config - https://spectrum.alioth.net/amiga/scalos-wb.tar.gz ) - note this requires original Kickstart ROMs to work.
2. Turn on the CPU and FPU jit in the F12 GUI
3. Launch AmigaAmp

Amiberry will crash before AmigaAmp finishes loading.
Repeating the above with only the CPU JIT turned on avoids the crash.

This is reproducable on a Raspberry Pi 5 with 32-bit Raspberry Pi OS (which uses a 64 bit kernel and 32 bit userland), also on a RPi4 with the same OS, as well as an Allwinner H6 board with an older 64-bit kernel and 32-bit userland.

Turning on logging in amiberry.conf and putting some code in to dump out the JIT's cache in the crash handler revealed the problem to to be an `LDRD` or `STRD` instruction being used on data that is not aligned on a 32 bit boundary. Replacing all `LDRD` and `STRD` instructions with a pair of `LDR` and `STR` instructions as appropriate fixed the problem:

```
15-518 [529 225-036]: Dumping JIT memory at e28f6000 compiled_code = e28f6800 length 16779264
15-549 [529 225-036]: --- New exception, signal_buserror ---
15-549 [529 225-036]: info.si_signo = 7
15-549 [529 225-036]: info.si_errno = 0
15-549 [529 225-036]: info.si_code = 1
15-549 [529 225-036]: info.si_addr = 606c0336
15-549 [529 225-036]: r0  = 0x00000400
15-549 [529 225-036]: r1  = 0x00000000
15-549 [529 225-036]: r2  = 0x00000000
15-549 [529 225-036]: r3  = 0x00000000
15-549 [529 225-036]: r4  = 0x0425c7d8
15-549 [529 225-036]: r5  = 0x00ada4f0
15-549 [529 225-036]: r6  = 0x00001600
15-549 [529 225-036]: r7  = 0x400009ff
15-549 [529 225-036]: r8  = 0x80800000
15-549 [529 225-036]: r9  = 0x406c0332
15-549 [529 225-036]: r10 = 0x20000000
15-549 [529 225-036]: FP  = 0x0425c7d8
15-549 [529 225-036]: IP  = 0x606c0332
15-549 [529 225-036]: SP  = 0xff895654
15-549 [529 225-036]: LR  = 0x0042dcac
15-549 [529 225-036]: PC  = 0xe29e89f8
15-549 [529 225-036]: CPSR = 0x60800010
15-549 [529 225-036]: Trap no = 0x00000000
15-549 [529 225-036]: Err Code = 0x00000000
15-549 [529 225-036]: Old Mask = 0x00000000
15-549 [529 225-036]: Fault Address = 0x606c0336
15-549 [529 225-036]: LR - 0x0042DCAC: <(null)> (./amiberry)
15-549 [529 225-036]: Stack trace:
15-549 [529 225-036]: 0x00379c24 <(null) + 0x00379c24> (./amiberry)
15-549 [529 225-036]: 0xf73ad2b0 <__default_rt_sa_restorer + 0x00000000> (/lib/arm-linux-gnueabihf/libc.so.6)
15-549 [529 225-036]: IP out of range
15-549 [529 225-036]: Stack trace (non-dedicated):
15-549 [529 225-036]: ./amiberry() [0x379d40]
15-549 [529 225-036]: /lib/arm-linux-gnueabihf/libc.so.6(__default_rt_sa_restorer+0) [0xf73ad2b0]
15-549 [529 225-036]: End of stack trace.
15-549 [529 225-036]: --- end exception ---
```

Snippet of JIT disassembly:

```
e29e89f0:       e59b9034        ldr     r9, [fp, #52]   @ 0x34
e29e89f4:       e089c00a        add     ip, r9, sl
e29e89f8:       e1cc20d4        ldrd    r2, [ip, #4]                 <<<------- crashes here
e29e89fc:       e3c22080        bic     r2, r2, #128    @ 0x80
e29e8a00:       ec432b18        vmov    d8, r2, r3
```

`IP` is set to an address not aligned to a 32-bit boundary `0x606c0032` (and therefore #4 is also unaligned, `0x606c0036`)

(The full log, dump of JIT memory, and disassembly is available at https://spectrum.alioth.net/amiga/alignment/ . The disassembly was generated with `objdump -m arm -b binary --adjust-vma=0xe28f6000 -D jitdump.bin >jitdump.S` - this was all performed on a RPi5 with a 32 bit userland)

Doing some reading on the subject, if the kernel is also 32 bit, the kernel will handle and fix up alignment problems such as this so it may not have been seen on ARM systems with both 32 bit kernel and userland. 64 bit kernels won't do these fix ups for 32 bit programs, so instead the program will crash.

However (and take this maybe with a pinch of salt, I'm not a kernel nor ARM expert) - I don't think `LDRD` or `STRD` should really being used even where the kernel is 32 bit because the kernel fixing up alignment problems will have a tremendous performance penalty if there's anything more than a minuscule number of unaligned memory accesses. Two `LDR` or `STR` instructions is bound to end up being faster in this case (although these suffer a performance penalty for unaligned access, this happens in the silicon rather than in the kernel so the performance hit isn't anywhere near as severe). It's also possible that not all the `LDRD/STRD` instructions needed to be replaced - but I'm not an expert in Amiberry's JIT and what parts of it are guaranteed to have aligned data, someone else will have to make that determination :-)

Changes proposed in this pull request:

Replace LDRD/STRD instructions with pairs of LDR/STR instructions. An `#ifdef ALLOW_UNALIGNED_LDRD` allows the original behaviour to be reinstated at compile time.

@midwan
