### PR TITLE
Set the devname and rootdir before calling updatehdfinfo

### DIFF
--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -7607,11 +7607,12 @@ static void parse_hardfile_spec (struct uae_prefs *p, const TCHAR *spec)
 #ifdef FILESYS
 	default_hfdlg(&current_hfdlg, false);
 	std::string txt1, txt2;
-	updatehdfinfo(true, false, false, txt1, txt2);
 
-	current_hfdlg.ci.type = UAEDEV_HDF;
 	_tcscpy(current_hfdlg.ci.devname, x1.c_str());
 	_tcscpy(current_hfdlg.ci.rootdir, x2.c_str());
+	updatehdfinfo(true, true, false, txt1, txt2);
+
+	current_hfdlg.ci.type = UAEDEV_HDF;
 	hardfile_testrdb(&current_hfdlg);
 
 	uaedev_config_info ci{};


### PR DESCRIPTION
Fixes the bug where a hard file provided on the command line results in a guru meditation in the emulated Amiga on boot due to the geometry not being set.

When amiberry-lite is launched as follows:

`amiberry-lite --model A4000 -r /path/to/kickstart.rom -W dh0:hardfile.hdf -G`

on boot, the emulated Amiga will crash with a software failure (guru meditation). Examining the value of `current_hfdlg.ci` in the debugger in `parse_hardfile_spec` (cfgfile.cpp, line 7595) shows that when updatehdfinfo is called, the path to the HDF/VHD file is not set nor is the device name, causing updatehdfinfo to not set the drive geometry because `hdf_open` fails within the function. Additionally, the second parameter (`bool defaults`) must be set to true for the geometry to be set. (This matches how the GUI uses this function when an HDF is selected in the hard drives panel).

Changes proposed in this pull request:
In `parse_hardfile_spec` in cfgfile.cpp:
- Move the string copy of the hard file name and the device name to before the call to `updatehdfinfo` so that `hdf_info` reads the HDF
- set parameter 2 of `updatehdfinfo` to true

@midwan
