### PR TITLE
Prevent joystick index from being out of range when setting key configs

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -308,8 +308,10 @@ static void set_key_configs(const uae_prefs* p)
 		for (int port = 0; port < 2; port++)
 		{
 			const auto host_joy_id = p->jports[port].id - JSEM_JOYS;
-			didata* did = &di_joystick[host_joy_id];
-			did->mapping.vkbd_button = vkbd_button;
+                        if(host_joy_id > -1 && host_joy_id < MAX_INPUT_DEVICES) {
+				didata* did = &di_joystick[host_joy_id];
+				did->mapping.vkbd_button = vkbd_button;
+                        }
 		}
 	}
 }


### PR DESCRIPTION
The joystick array index can be out of bounds in set_key_configs.
If the port id isn't in the range JSEM_JOYS to JSEM_JOYS + MAX_INPUT_DEVICES, an invalid array index will be used which can lead to a crash.

Changes proposed in this pull request:
- Check that the resulting host_joy_id is within range.

@midwan
