### PR TITLE
Avoid unaligned access with certain 32-bit ARM instructions

### DIFF
--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -34,6 +34,10 @@ elseif(CMAKE_BUILD_TYPE)
     add_compile_options("-O1")
 endif()
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
+    add_compile_options("-mno-unaligned-access")
+endif ()
+
 # Platform-specific linker flags
 if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
     add_link_options("-Wl,--no-undefined" "-Wl,-z,combreloc" "-Wl,--as-needed")


### PR DESCRIPTION
On 32 bit ARM targets, on certain compiler optimisation levels, the compiler can generate unaligned stm/strd/ldm/ldrd instructions. On a 32 bit userland with a 64 bit kernel this will cause the emulator to crash with an alignment exception. (I think 32 bit kernels will fix up the alignment fault, but in doing so will incur a significant performance penalty).

Changes proposed in this pull request:

Adds a compiler flag to tell the compiler not to do this (`-mno-unaligned-access`) for 32 bit ARM builds.

@midwan
